### PR TITLE
I fixed the Makefile so it builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PREFIX = /usr/local
-CFLAGS += -Wall -Werror -std=c99 -c
+CFLAGS += -Wall -Werror -std=c99 -c -D_GNU_SOURCE
 
 .PHONY:
 	all clean install


### PR DESCRIPTION
Fix Makefile so gcc can find the declaration for strdup() in string.h when -std=c99 is in effect.
